### PR TITLE
The header must be passed while requesting a WSDL

### DIFF
--- a/suds/transport/http.py
+++ b/suds/transport/http.py
@@ -60,8 +60,9 @@ class HttpTransport(Transport):
     def open(self, request):
         try:
             url = self.__get_request_url_for_urllib(request)
+            headers = request.headers
             log.debug('opening (%s)', url)
-            u2request = urllib2.Request(url)
+            u2request = urllib2.Request(url, headers=headers)
             self.proxy = self.options.proxy
             return self.u2open(u2request)
         except urllib2.HTTPError, e:


### PR DESCRIPTION
because some servers might require credentials to give access to it.
Servers configured like will return a 401 error even though credentials were passed at the Client creation if the headers are not passed along.