### PR TITLE
Fix exception when running http test

### DIFF
--- a/tests/test_transport_http.py
+++ b/tests/test_transport_http.py
@@ -120,6 +120,9 @@ class MockFP:
     def readline():
         raise MustNotBeCalled
 
+    def close(self):
+        pass
+
 
 class MockURLOpenerSaboteur:
     """


### PR DESCRIPTION
Fix the below exception by adding a close() method to the MockFP:
Exception ignored in: <function _TemporaryFileCloser.__del__ at 0x7f03bd5369d8>
Traceback (most recent call last):
  File "/usr/lib64/python3.7/tempfile.py", line 448, in __del__
    self.close()
  File "/usr/lib64/python3.7/tempfile.py", line 441, in close
    self.file.close()
AttributeError: 'MockFP' object has no attribute 'close'