### PR TITLE
ResourceWarning: unclosed cache file & Invalid escape sequence warnings

### DIFF
--- a/suds/cache.py
+++ b/suds/cache.py
@@ -285,10 +285,11 @@ class DocumentCache(FileCache):
         fp = None
         try:
             fp = self._getf(id)
-            if fp is None:
-                return None
-            p = suds.sax.parser.Parser()
-            return p.parse(fp)
+            if fp is not None:
+                p = suds.sax.parser.Parser()
+                cached = p.parse(fp)
+                fp.close()
+                return cached
         except Exception:
             if fp is not None:
                 fp.close()
@@ -319,7 +320,9 @@ class ObjectCache(FileCache):
         try:
             fp = self._getf(id)
             if fp is not None:
-                return pickle.load(fp)
+                cached = pickle.load(fp)
+                fp.close()
+                return cached
         except Exception:
             if fp is not None:
                 fp.close()

--- a/tests/test_sax_element.py
+++ b/tests/test_sax_element.py
@@ -160,7 +160,7 @@ class TestStringRepresentation:
 
     def test_plain_method(self):
         element = self.create_test_element(self.str_formatted_xml)
-        expected = re.sub("\s*[\r\n]\s*", "", self.str_formatted_xml)
+        expected = re.sub(r"\s*[\r\n]\s*", "", self.str_formatted_xml)
         result = element.plain()
         assert result == expected
 

--- a/tests/test_sax_encoder.py
+++ b/tests/test_sax_encoder.py
@@ -59,7 +59,7 @@ the current encode()/decode() operation implementations are broken.
 invariant_decoded_encoded_test_data__broken = (
     # CDATA handling.
     "<![CDATA['\"&<> \t\r\n\v\f &lt; &gt; &apos; &quot; &amp;]]>",
-    "<![CDATA[\\'\\\"\\&\\<\\> \\&lt; \\&gt; \\&apos; \\&quot; ]\&amp;]]>",
+    "<![CDATA[\\'\\\"\\&\\<\\> \\&lt; \\&gt; \\&apos; \\&quot; ]\\&amp;]]>",
     "<![CDATA[&&<><><><>>>>><<<< This is !!!&& &amp; a test...."
         "<<>>>>>>>>}}>]?]>>>>]]>")
 

--- a/tests/test_suds.py
+++ b/tests/test_suds.py
@@ -225,7 +225,7 @@ def test_converting_metadata_to_string():
     assert len(metadata) == 2
     metadata_string = str(metadata)
     assert re.search(" sxtype = ", metadata_string)
-    assert re.search(" ordering\[\] = ", metadata_string)
+    assert re.search(r" ordering\[\] = ", metadata_string)
 
 
 def test_empty_invalid_WSDL(monkeypatch):


### PR DESCRIPTION
pytest 5.3.0 show a bunch of annoying warnings that could be easily fixed.
While "Invalid escape" represented by project's testcase itself, I've got also "ResourceWarning: unclosed file" on prod environment with Python==3.7.4, suds-community==0.8.3, pytest==4.6.6