### PR TITLE
Resolve invalid escape warnings

### DIFF
--- a/suds/resolver.py
+++ b/suds/resolver.py
@@ -86,7 +86,7 @@ class PathResolver(Resolver):
         Resolver.__init__(self, wsdl.schema)
         self.wsdl = wsdl
         self.altp = re.compile('({)(.+)(})(.+)')
-        self.splitp = re.compile('({.+})*[^\%s]+' % ps[0])
+        self.splitp = re.compile('({.+})*[^\\%s]+' % ps[0])
 
     def find(self, path, resolved=True):
         """

--- a/suds/wsdl.py
+++ b/suds/wsdl.py
@@ -664,7 +664,7 @@ class Binding(NamedObject):
         if parts is None:
             body.parts = ()
         else:
-            body.parts = re.split("[\s,]", parts)
+            body.parts = re.split("[\\s,]", parts)
         body.use = root.get("use", default="literal")
         ns = root.get("namespace")
         if ns is None:


### PR DESCRIPTION
Resolve the following warnings:

    .../suds/resolver.py:89: DeprecationWarning: invalid escape sequence \%
      self.splitp = re.compile('({.+})*[^\%s]+' % ps[0])
    .../suds/wsdl.py:619: DeprecationWarning: invalid escape sequence \s
      body.parts = re.split('[\s,]', parts)

These will be an error in a future release of Python.