### PR TITLE
Remove tools/*.cmd from MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -19,7 +19,6 @@ include notes/*.txt
 recursive-include tests *.py
 
 # Project development & setup tools.
-include tools/*.cmd
 include tools/*.py
 include tools/*.txt
 recursive-include tools/suds_devel *.py


### PR DESCRIPTION
Saves a warning during install:

reading manifest template 'MANIFEST.in'
warning: no files found matching 'tools/*.cmd'

.cmd file was removed in:

1b1ccdd ("port tools/run_all_tests.cmd to Python", 2014-05-29)