### PR TITLE
typo README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -882,7 +882,7 @@ Now, if the wsdl defines:
 
 Suds will be forced to report the method `foo` signature as:
 
-    foo(Foo foo, xs:int bar)
+    foo(Foo foo, xs:string bar)
 
 The message has (2) parts which defines that the message payload
 contains (2) documents. In this case, suds must present a /Document/


### PR DESCRIPTION
the description of "bar" is string but the example was showing int, either one of them has to change