### PR TITLE
Convert CP1250 files to UTF8

### DIFF
--- a/TODO.txt
+++ b/TODO.txt
@@ -302,7 +302,7 @@ PRIORITIZED:
 
 (28.02.2013.)
 
-(+) * (Jurko) Merge changes prepared by Juraj Ivanèiæ.
+(+) * (Jurko) Merge changes prepared by Juraj IvanÄiÄ‡.
 (+)     * Update the original Hg repository containing Python 3 related fixes.
 (+) * (Jurko) Process received pull requests.
 
@@ -413,7 +413,7 @@ PRIORITIZED:
 (01.04.2013.)
 
 (+) * (Jurko) Add tests for wrapped suds operation output data.
-(+) * (Jurko) Merge patches sent in by Juraj Ivanèiæ from PKE sistemi.
+(+) * (Jurko) Merge patches sent in by Juraj IvanÄiÄ‡ from PKE sistemi.
 (+)     * Add tests for disabled wrapped suds operation input & output data
 (+)       support.
 (+)     * Add code for disabling suds library wrapped parameter support.
@@ -421,7 +421,7 @@ PRIORITIZED:
 (02.04.2013.)
 
 (+) * (Jurko) Restriction support cleanup based on patches sent in by Juraj
-(+)   Ivanèiæ from PKE sistemi.
+(+)   IvanÄiÄ‡ from PKE sistemi.
 (+)     * Research.
 (+)         * Not enough time to research this thoroughly and come up with a
 (+)           complete and well tested solution.

--- a/notes/argument_parsing.rst
+++ b/notes/argument_parsing.rst
@@ -1,7 +1,7 @@
 ===================================================================
 Notes on input argument usage when invoking a web service operation
 ===================================================================
-:Authors: Jurko Gospodnetiæ
+:Authors: Jurko GospodnetiÄ‡
 :Date: 2014-01-23
 
 

--- a/notes/traversing_client_data.rst
+++ b/notes/traversing_client_data.rst
@@ -1,7 +1,7 @@
 ================================================
 Examples on traversing suds library's data model
 ================================================
-:Authors: Jurko Gospodnetiæ
+:Authors: Jurko GospodnetiÄ‡
 :Date: 2014-01-23
 
 Get service from client::

--- a/notes/wsdl_soap_binding.rst
+++ b/notes/wsdl_soap_binding.rst
@@ -1,7 +1,7 @@
 ================================
 WSDL SOAP binding research notes
 ================================
-:Authors: Jurko Gospodnetiæ
+:Authors: Jurko GospodnetiÄ‡
 :Date: 2014-06-30
 
 

--- a/notes/xsd_elements.rst
+++ b/notes/xsd_elements.rst
@@ -1,7 +1,7 @@
 ==========================
 XSD element research notes
 ==========================
-:Authors: Jurko Gospodnetiæ
+:Authors: Jurko GospodnetiÄ‡
 :Date: 2014-06-29
 
 

--- a/notes/xsd_types.rst
+++ b/notes/xsd_types.rst
@@ -1,7 +1,7 @@
 ==========================
 Modeling XSD types in suds
 ==========================
-:Authors: Jurko Gospodnetiæ
+:Authors: Jurko GospodnetiÄ‡
 :Date: 2014-01-29
 
 XSD types can be one of the following:

--- a/tools/run_all_tests.py
+++ b/tools/run_all_tests.py
@@ -13,7 +13,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program; if not, write to the Free Software Foundation, Inc.,
 # 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
-# written by: Jurko Gospodnetiæ ( jurko.gospodnetic@pke.hr )
+# written by: Jurko GospodnetiÄ‡ ( jurko.gospodnetic@pke.hr )
 
 """
 "poor man's tox" development script used on Windows to run the full suds-jurko

--- a/tools/suds_devel/__init__.py
+++ b/tools/suds_devel/__init__.py
@@ -13,7 +13,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program; if not, write to the Free Software Foundation, Inc.,
 # 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
-# written by: Jurko Gospodnetiæ ( jurko.gospodnetic@pke.hr )
+# written by: Jurko GospodnetiÄ‡ ( jurko.gospodnetic@pke.hr )
 
 """
 Internal implementation package for different project development utility


### PR DESCRIPTION
Hi,
This fixes `SyntaxError: Non-UTF-8 code in coment` when PyPy3 is used. Not that tests pass with PyPy3 but still this makes the code more legible :smiley: 