### PR TITLE
Do not force byte-compilation optimization at level 1

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -21,16 +21,6 @@
 #   'derived' with the value 'Foo-Bar'
 
 
-# --------------------
-# --- Build system ---
-# --------------------
-
-[install]
-# Added in the original project as a fix (trunk SVN revision 7) for a problem
-# with missing .pyo files when building rpms with Python 2.4.
-optimize = 1
-
-
 # --------------------------------------
 # --- Test & development environment ---
 # --------------------------------------


### PR DESCRIPTION
This prevented extra-optimized files (level 2, like `python -OO`) to be created.