### PR TITLE
docs: fix simple typo: ouput -> output

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ Service (WebServiceTestBeanService) tns="http://test.server.enterprise.rhq.org/"
 
 note: See example of service with multiple ports below.
 
-The sample ouput lists that the service named
+The sample output lists that the service named
 `WebServiceTestBeanService` has methods such as
 getPercentBodyFat() and addPerson().
 


### PR DESCRIPTION
There is a simple typo in the README.md

Replaced ouput with output