### PR TITLE
Restore last_sent and last_received functions

### DIFF
--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -665,6 +665,8 @@ class TestTransportUsage:
         assert b(xsd_target_namespace) in request_message
         assert b(test_input_data) in request_message
         assert reply == test_output_data
+        assert client.messages.get("rx") == client.last_received()
+        assert client.messages.get("tx") == client.last_sent()
 
     @pytest.mark.parametrize("transport", (object(), suds.cache.NoCache()))
     def test_reject_invalid_transport_class(self, transport, monkeypatch):


### PR DESCRIPTION
This revert 8eaf105 with add back the two _SoapClient functions.

Also add back the messages attribute of the client class.

The messages attribute and two functions could be used to get the
send/reply message Document of soap request, which could be used to
get the element like 'sessionId' of a soap session.

Updated test_operation_request_and_reply with the messages
attribute and function check.

This resolves issue:
https://github.com/suds-community/suds/issues/79

Signed-off-by: Wayne Sun <gsun@redhat.com>