### PR TITLE
Remove support from before Python 3.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -684,11 +684,10 @@ setup(
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3 :: Only",
-        "Programming Language :: Python :: 3.5",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
         "Topic :: Internet"],
 
     # PEP-314 states that, if possible, license & platform should be specified
@@ -698,6 +697,6 @@ setup(
 
     # Register distutils command customizations.
     cmdclass=distutils_cmdclass,
-    python_requires=">=3.5",
+    python_requires=">=3.7",
 
     **extra_setup_params)


### PR DESCRIPTION
Suds should not be allowed to be installed on versions of Python that are no
longer being tested against.

See https://github.com/suds-community/suds/blob/b7a9a0e9e0ec7f3264251292ad556532904007ec/.github/workflows/test_and_release.yml#L8.