### PR TITLE
Remove Python version checks and use of six in tests

### DIFF
--- a/HACKING.rst
+++ b/HACKING.rst
@@ -16,7 +16,6 @@ Separate sections below:
 * `PYTHON COMPATIBILITY`_
 * `RELEASE PROCEDURE`_
 * `DEVELOPMENT & TESTING ENVIRONMENT`_
-* `PYTHON 2/3 SOURCE CODE COMPATIBILITY`_
 * `EXTERNAL DOCUMENTATION`_
 * `STANDARDS CONFORMANCE`_
 * `PROJECT IMPLEMENTATION NOTES`_
@@ -549,25 +548,6 @@ some external Python package installation tool requiring those entries in order
 to determine where to install its package data. In that case you can set those
 entries manually, e.g. by using a script similar to the one found at
 `<http://nedbatchelder.com/blog/201007/installing_python_packages_from_windows_installers_into.html>`_.
-
-
-PYTHON 2/3 SOURCE CODE COMPATIBILITY
-=================================================
-
-These are notes related to maintaining Python 2/3 source code compatibility in
-parts of this project that require it.
-
-Use the ``six <http://pythonhosted.org/six>`` Python 2/3 compatibility support
-package to make the compatibility patches simpler. Where a solution provided by
-``six`` can not be used, explicitly explain the reason why in a related code
-comment.
-
-Do not use ``u"..."`` Python unicode literals since we wish to support Python
-3.1 & 3.2 versions which do not support them. Useful site for easily converting
-unicode strings to their ``unicode-escape`` encoded representation which can
-then be used with the ``six.u()`` helper function:
-
-  http://www.rapidmonkey.com/unicodeconverter
 
 
 EXTERNAL DOCUMENTATION

--- a/setup.py
+++ b/setup.py
@@ -122,7 +122,7 @@ import suds_devel
 sys.path.pop(0)
 
 from suds_devel.requirements import (check_Python24_pytest_requirements,
-    pytest_requirements, six_requirements)
+    pytest_requirements)
 
 
 # -----------------------------------------------------------------------------
@@ -482,7 +482,6 @@ def test_requirements():
     result = []
     if include_pytest_requirements:
         result.extend(pytest_requirements())
-    result.extend(six_requirements())
     return result
 
 test_error = None

--- a/tests/external/axis1.py
+++ b/tests/external/axis1.py
@@ -89,7 +89,7 @@ try:
     #
     print('create name')
     name = client.factory.create('ns0:Name')
-    name.first = u'jeff'+unichr(1234)
+    name.first = u'jeff'+chr(1234)
     name.last = 'ortel'
     print(name)
     #

--- a/tests/external/axis2.py
+++ b/tests/external/axis2.py
@@ -44,7 +44,7 @@ print(client.service.printList(['a', 'b']))
 #
 print('create name')
 name = client.factory.create('ns2:Name')
-name.first = u'jeff'+unichr(1234)
+name.first = u'jeff'+chr(1234)
 name.last = 'ortel'
 
 print(name)

--- a/tests/external/rhq.py
+++ b/tests/external/rhq.py
@@ -50,7 +50,7 @@ def rhqTest():
         # create name
         #
         name = client.factory.create('name')
-        name.first = u'Jeff'+unichr(1234)
+        name.first = u'Jeff'+chr(1234)
         name.last = 'Ortel &amp;lt; Company'
         #
         # create a phone object using the wsdl

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -31,7 +31,6 @@ import suds.cache
 import suds.sax.parser
 
 import pytest
-from six import b, next, u
 
 import datetime
 import os
@@ -163,18 +162,18 @@ class MockPickleLoad:
 
 
 # Hardcoded values used in different caching test cases.
-value_empty = b("")
-value_f2 = b("fifi2")
-value_f22 = b("fifi22")
-value_f3 = b("fifi3")
-value_p1 = b("pero1")
-value_p11 = b("pero11")
-value_p111 = b("pero111")
-value_p2 = b("pero2")
-value_p22 = b("pero22")
-value_unicode = u("\u20AC \u7684 "
+value_empty = b""
+value_f2 = b"fifi2"
+value_f22 = b"fifi22"
+value_f3 = b"fifi3"
+value_p1 = b"pero1"
+value_p11 = b"pero11"
+value_p111 = b"pero111"
+value_p2 = b"pero2"
+value_p22 = b"pero22"
+value_unicode = ("\u20AC \u7684 "
     "\u010D\u0107\u017E\u0161\u0111"
-    "\u010C\u0106\u017D\u0160\u0110").encode("utf-8")
+    "\u010C\u0106\u017D\u0160\u0110").encode()
 
 
 # FileCache item expiration test data - duration, current_time, expect_remove.

--- a/tests/test_compare_sax.py
+++ b/tests/test_compare_sax.py
@@ -31,7 +31,6 @@ from testutils.assertion import assert_no_output
 from testutils.compare_sax import CompareSAX
 
 import pytest
-from six import text_type, u
 
 import xml.sax
 
@@ -79,14 +78,14 @@ class TestMatched:
         ('<a xmlns="one"/>', '<ns:a xmlns:ns="one"/>'),
         ('<ns1:b xmlns:ns1="two"/>', '<ns2:b xmlns:ns2="two"/>'),
         # Numeric unicode character references.
-        (u("<a>\u2606</a>"), "<a>&#%d;</a>" % (0x2606,))))
+        ("<a>\u2606</a>", "<a>&#%d;</a>" % (0x2606,))))
     def test_data2data(self, data1, data2, capsys):
         CompareSAX.data2data(data1, data2)
         assert_no_output(capsys)
 
     @skip_test_if_CompareSAX_assertions_disabled
-    @pytest.mark.parametrize("type1", (suds.byte_str, text_type))
-    @pytest.mark.parametrize("type2", (suds.byte_str, text_type))
+    @pytest.mark.parametrize("type1", (suds.byte_str, str))
+    @pytest.mark.parametrize("type2", (suds.byte_str, str))
     def test_string_input_types(self, type1, type2, capsys):
         xml = "<a/>"
         CompareSAX.data2data(type1(xml), type2(xml))
@@ -95,7 +94,7 @@ class TestMatched:
     @skip_test_if_CompareSAX_assertions_disabled
     def test_xml_encoding(self, capsys):
         """Test that the encoding listed in the XML declaration is honored."""
-        xml_format = u('<?xml version="1.0" encoding="%s"?><a>\u00D8</a>')
+        xml_format = '<?xml version="1.0" encoding="%s"?><a>\u00D8</a>'
         data1 = (xml_format % ("UTF-8",)).encode('utf-8')
         data2 = (xml_format % ("latin1",)).encode('latin1')
         CompareSAX.data2data(data1, data2)

--- a/tests/test_dependency_sort.py
+++ b/tests/test_dependency_sort.py
@@ -29,7 +29,6 @@ if __name__ == "__main__":
 from suds.xsd.depsort import dependency_sort
 
 import pytest
-from six import iteritems
 
 import copy
 
@@ -68,7 +67,7 @@ _test_dependency_tree = {
 def test_dependency_sort():
     dependency_tree = _test_dependency_tree
     result = dependency_sort(dependency_tree)
-    assert sorted(result) == sorted(iteritems(dependency_tree))
+    assert sorted(result) == sorted(dependency_tree.items())
     _assert_dependency_order((x[0] for x in result), dependency_tree)
 
 
@@ -78,7 +77,7 @@ def test_dependency_sort_does_not_mutate_input():
     # save the original dependency tree structure information
     expected_deps = {}
     expected_deps_ids = {}
-    for x, y in iteritems(dependency_tree):
+    for x, y in dependency_tree.items():
         expected_deps[x] = copy.copy(y)
         expected_deps_ids[id(x)] = id(y)
 
@@ -87,7 +86,7 @@ def test_dependency_sort_does_not_mutate_input():
 
     # verify that the dependency tree structure is unchanged
     assert len(dependency_tree) == len(expected_deps)
-    for key, deps in iteritems(dependency_tree):
+    for key, deps in dependency_tree.items():
         # same deps for each key
         assert id(deps) == expected_deps_ids[id(key)]
         # deps structure compare with the original copy
@@ -146,12 +145,12 @@ def _transitive_dependency_closure(dependencies):
 
     """
     def clone(deps):
-        return dict((k, set(v)) for k, v in iteritems(deps))
+        return dict((k, set(v)) for k, v in deps.items())
     closure = None
     new = clone(dependencies)
     while new != closure:
         closure = clone(new)
-        for k, deps in iteritems(closure):
+        for k, deps in closure.items():
             for dep in deps:
                 new[k] |= closure[dep]
     return closure

--- a/tests/test_reply_handling.py
+++ b/tests/test_reply_handling.py
@@ -29,9 +29,8 @@ if __name__ == "__main__":
 import suds
 
 import pytest
-from six import itervalues, next, u
-from six.moves import http_client
 
+import http.client
 import xml.sax
 
 
@@ -41,11 +40,11 @@ def test_ACCEPTED_and_NO_CONTENT_status_reported_as_None_with_faults():
         inject = {"reply": suds.byte_str(reply), "status": status}
         return client.service.f(__inject=inject)
     assert f("", None) is None
-    pytest.raises(Exception, f, "", http_client.INTERNAL_SERVER_ERROR)
-    assert f("", http_client.ACCEPTED) is None
-    assert f("", http_client.NO_CONTENT) is None
-    assert f("bla-bla", http_client.ACCEPTED) is None
-    assert f("bla-bla", http_client.NO_CONTENT) is None
+    pytest.raises(Exception, f, "", http.client.INTERNAL_SERVER_ERROR)
+    assert f("", http.client.ACCEPTED) is None
+    assert f("", http.client.NO_CONTENT) is None
+    assert f("bla-bla", http.client.ACCEPTED) is None
+    assert f("bla-bla", http.client.NO_CONTENT) is None
 
 
 def test_ACCEPTED_and_NO_CONTENT_status_reported_as_None_without_faults():
@@ -54,11 +53,11 @@ def test_ACCEPTED_and_NO_CONTENT_status_reported_as_None_without_faults():
         inject = {"reply": suds.byte_str(reply), "status": status}
         return client.service.f(__inject=inject)
     assert f("", None) is not None
-    assert f("", http_client.INTERNAL_SERVER_ERROR) is not None
-    assert f("", http_client.ACCEPTED) is None
-    assert f("", http_client.NO_CONTENT) is None
-    assert f("bla-bla", http_client.ACCEPTED) is None
-    assert f("bla-bla", http_client.NO_CONTENT) is None
+    assert f("", http.client.INTERNAL_SERVER_ERROR) is not None
+    assert f("", http.client.ACCEPTED) is None
+    assert f("", http.client.NO_CONTENT) is None
+    assert f("bla-bla", http.client.ACCEPTED) is None
+    assert f("bla-bla", http.client.NO_CONTENT) is None
 
 
 def test_badly_formed_reply_XML():
@@ -160,29 +159,29 @@ def test_empty_reply():
             description=description)
         return client.service.f(__inject=inject)
     status, reason = f()
-    assert status == http_client.OK
+    assert status == http.client.OK
     assert reason is None
-    status, reason = f(http_client.OK)
-    assert status == http_client.OK
+    status, reason = f(http.client.OK)
+    assert status == http.client.OK
     assert reason is None
-    status, reason = f(http_client.INTERNAL_SERVER_ERROR)
-    assert status == http_client.INTERNAL_SERVER_ERROR
+    status, reason = f(http.client.INTERNAL_SERVER_ERROR)
+    assert status == http.client.INTERNAL_SERVER_ERROR
     assert reason == "injected reply"
-    status, reason = f(http_client.FORBIDDEN)
-    assert status == http_client.FORBIDDEN
+    status, reason = f(http.client.FORBIDDEN)
+    assert status == http.client.FORBIDDEN
     assert reason == "injected reply"
-    status, reason = f(http_client.FORBIDDEN, "kwack")
-    assert status == http_client.FORBIDDEN
+    status, reason = f(http.client.FORBIDDEN, "kwack")
+    assert status == http.client.FORBIDDEN
     assert reason == "kwack"
 
 
 def test_fault_reply_with_unicode_faultstring(monkeypatch):
     monkeypatch.delitem(locals(), "e", False)
 
-    unicode_string = u("\u20AC Jurko Gospodneti\u0107 "
+    unicode_string = ("\u20AC Jurko Gospodneti\u0107 "
         "\u010C\u0106\u017D\u0160\u0110"
         "\u010D\u0107\u017E\u0161\u0111")
-    fault_xml = suds.byte_str(u("""\
+    fault_xml = suds.byte_str("""\
 <?xml version="1.0"?>
 <env:Envelope xmlns:env="http://schemas.xmlsoap.org/soap/envelope/">
   <env:Body>
@@ -192,10 +191,10 @@ def test_fault_reply_with_unicode_faultstring(monkeypatch):
     </env:Fault>
   </env:Body>
 </env:Envelope>
-""") % (unicode_string,))
+""" % (unicode_string,))
 
     client = testutils.client_from_wsdl(_wsdl__simple_f, faults=True)
-    inject = dict(reply=fault_xml, status=http_client.INTERNAL_SERVER_ERROR)
+    inject = dict(reply=fault_xml, status=http.client.INTERNAL_SERVER_ERROR)
     e = pytest.raises(suds.WebFault, client.service.f, __inject=inject).value
     try:
         assert e.fault.faultstring == unicode_string
@@ -205,8 +204,8 @@ def test_fault_reply_with_unicode_faultstring(monkeypatch):
 
     client = testutils.client_from_wsdl(_wsdl__simple_f, faults=False)
     status, fault = client.service.f(__inject=dict(reply=fault_xml,
-        status=http_client.INTERNAL_SERVER_ERROR))
-    assert status == http_client.INTERNAL_SERVER_ERROR
+        status=http.client.INTERNAL_SERVER_ERROR))
+    assert status == http.client.INTERNAL_SERVER_ERROR
     assert fault.faultstring == unicode_string
 
 
@@ -228,7 +227,7 @@ def test_invalid_fault_namespace(monkeypatch):
 </env:Envelope>
 """)
     client = testutils.client_from_wsdl(_wsdl__simple_f, faults=False)
-    inject = dict(reply=fault_xml, status=http_client.OK)
+    inject = dict(reply=fault_xml, status=http.client.OK)
     e = pytest.raises(Exception, client.service.f, __inject=inject).value
     try:
         assert e.__class__ is Exception
@@ -236,8 +235,8 @@ def test_invalid_fault_namespace(monkeypatch):
     finally:
         del e  # explicitly break circular reference chain in Python 3
 
-    for http_status in (http_client.INTERNAL_SERVER_ERROR,
-        http_client.PAYMENT_REQUIRED):
+    for http_status in (http.client.INTERNAL_SERVER_ERROR,
+        http.client.PAYMENT_REQUIRED):
         status, reason = client.service.f(__inject=dict(reply=fault_xml,
             status=http_status, description="trla baba lan"))
         assert status == http_status
@@ -275,7 +274,7 @@ def test_reply_error_with_detail_with_fault(monkeypatch):
 
     client = testutils.client_from_wsdl(_wsdl__simple_f, faults=True)
 
-    for http_status in (http_client.OK, http_client.INTERNAL_SERVER_ERROR):
+    for http_status in (http.client.OK, http.client.INTERNAL_SERVER_ERROR):
         inject = dict(reply=_fault_reply__with_detail, status=http_status)
         e = pytest.raises(suds.WebFault, client.service.f, __inject=inject)
         try:
@@ -287,11 +286,11 @@ def test_reply_error_with_detail_with_fault(monkeypatch):
             del e  # explicitly break circular reference chain in Python 3
 
     inject = dict(reply=_fault_reply__with_detail,
-        status=http_client.BAD_REQUEST, description="quack-quack")
+        status=http.client.BAD_REQUEST, description="quack-quack")
     e = pytest.raises(Exception, client.service.f, __inject=inject).value
     try:
         assert e.__class__ is Exception
-        assert e.args[0][0] == http_client.BAD_REQUEST
+        assert e.args[0][0] == http.client.BAD_REQUEST
         assert e.args[0][1] == "quack-quack"
     finally:
         del e  # explicitly break circular reference chain in Python 3
@@ -300,21 +299,21 @@ def test_reply_error_with_detail_with_fault(monkeypatch):
 def test_reply_error_with_detail_without_fault():
     client = testutils.client_from_wsdl(_wsdl__simple_f, faults=False)
 
-    for http_status in (http_client.OK, http_client.INTERNAL_SERVER_ERROR):
+    for http_status in (http.client.OK, http.client.INTERNAL_SERVER_ERROR):
         status, fault = client.service.f(__inject=dict(
             reply=_fault_reply__with_detail, status=http_status))
-        assert status == http_client.INTERNAL_SERVER_ERROR
+        assert status == http.client.INTERNAL_SERVER_ERROR
         _test_fault(fault, True)
 
     status, fault = client.service.f(__inject=dict(
-        reply=_fault_reply__with_detail, status=http_client.BAD_REQUEST))
-    assert status == http_client.BAD_REQUEST
+        reply=_fault_reply__with_detail, status=http.client.BAD_REQUEST))
+    assert status == http.client.BAD_REQUEST
     assert fault == "injected reply"
 
     status, fault = client.service.f(__inject=dict(
-        reply=_fault_reply__with_detail, status=http_client.BAD_REQUEST,
+        reply=_fault_reply__with_detail, status=http.client.BAD_REQUEST,
         description="haleluja"))
-    assert status == http_client.BAD_REQUEST
+    assert status == http.client.BAD_REQUEST
     assert fault == "haleluja"
 
 
@@ -323,7 +322,7 @@ def test_reply_error_without_detail_with_fault(monkeypatch):
 
     client = testutils.client_from_wsdl(_wsdl__simple_f, faults=True)
 
-    for http_status in (http_client.OK, http_client.INTERNAL_SERVER_ERROR):
+    for http_status in (http.client.OK, http.client.INTERNAL_SERVER_ERROR):
         inject = dict(reply=_fault_reply__without_detail, status=http_status)
         e = pytest.raises(suds.WebFault, client.service.f, __inject=inject)
         try:
@@ -335,11 +334,11 @@ def test_reply_error_without_detail_with_fault(monkeypatch):
             del e  # explicitly break circular reference chain in Python 3
 
     inject = dict(reply=_fault_reply__with_detail,
-        status=http_client.BAD_REQUEST, description="quack-quack")
+        status=http.client.BAD_REQUEST, description="quack-quack")
     e = pytest.raises(Exception, client.service.f, __inject=inject).value
     try:
         assert e.__class__ is Exception
-        assert e.args[0][0] == http_client.BAD_REQUEST
+        assert e.args[0][0] == http.client.BAD_REQUEST
         assert e.args[0][1] == "quack-quack"
     finally:
         del e  # explicitly break circular reference chain in Python 3
@@ -348,16 +347,16 @@ def test_reply_error_without_detail_with_fault(monkeypatch):
 def test_reply_error_without_detail_without_fault():
     client = testutils.client_from_wsdl(_wsdl__simple_f, faults=False)
 
-    for http_status in (http_client.OK, http_client.INTERNAL_SERVER_ERROR):
+    for http_status in (http.client.OK, http.client.INTERNAL_SERVER_ERROR):
         status, fault = client.service.f(__inject=dict(
             reply=_fault_reply__without_detail, status=http_status))
-        assert status == http_client.INTERNAL_SERVER_ERROR
+        assert status == http.client.INTERNAL_SERVER_ERROR
         _test_fault(fault, False)
 
     status, fault = client.service.f(__inject=dict(
-        reply=_fault_reply__without_detail, status=http_client.BAD_REQUEST,
+        reply=_fault_reply__without_detail, status=http.client.BAD_REQUEST,
         description="kung-fu-fui"))
-    assert status == http_client.BAD_REQUEST
+    assert status == http.client.BAD_REQUEST
     assert fault == "kung-fu-fui"
 
 
@@ -491,7 +490,7 @@ def _attributes(object):
 
 def _isOutputWrapped(client, method_name):
     assert len(client.wsdl.bindings) == 1
-    binding = next(itervalues(client.wsdl.bindings))
+    binding = next(iter(client.wsdl.bindings.values()))
     operation = binding.operations[method_name]
     return operation.soap.output.body.wrapped
 

--- a/tests/test_request_construction.py
+++ b/tests/test_request_construction.py
@@ -38,7 +38,6 @@ import suds
 import suds.store
 
 import pytest
-from six import iterkeys, itervalues, next, u
 
 
 #TODO: Update the current restriction type output parameter handling so such
@@ -673,7 +672,7 @@ def test_missing_parameters():
   </Body>
 </Envelope>""" % (xsd_target_namespace,))
 
-    _assert_request_content(service.f((u("Pero \u017Ddero"))), u("""\
+    _assert_request_content(service.f(("Pero \u017Ddero")), """\
 <?xml version="1.0" encoding="UTF-8"?>
 <Envelope xmlns="http://schemas.xmlsoap.org/soap/envelope/">
   <Header/>
@@ -683,7 +682,7 @@ def test_missing_parameters():
       <anInteger/>
     </Wrapper>
   </Body>
-</Envelope>""") % (xsd_target_namespace,))
+</Envelope>""" % (xsd_target_namespace,))
 
     _assert_request_content(service.f(anInteger=666), """\
 <?xml version="1.0" encoding="UTF-8"?>
@@ -1033,7 +1032,7 @@ def test_twice_wrapped_parameter():
     # Web service operation calls made with 'invalid' parameters.
     def test_invalid_parameter(**kwargs):
         assert len(kwargs) == 1
-        keyword = next(iterkeys(kwargs))
+        keyword = next(iter(kwargs.keys()))
         expected = "f() got an unexpected keyword argument '%s'" % (keyword,)
         e = pytest.raises(TypeError, client.service.f, **kwargs).value
         try:
@@ -1166,7 +1165,7 @@ def test_wrapped_parameter(monkeypatch):
 
 def _is_input_wrapped(client, method_name):
     assert len(client.wsdl.bindings) == 1
-    binding = next(itervalues(client.wsdl.bindings))
+    binding = next(iter(client.wsdl.bindings.values()))
     operation = binding.operations[method_name]
     return operation.soap.input.body.wrapped
 

--- a/tests/test_sax_document.py
+++ b/tests/test_sax_document.py
@@ -30,10 +30,7 @@ import suds
 from suds.sax.document import Document
 import suds.sax.parser
 
-import pytest
-
 import re
-import sys
 
 
 class TestStringRepresentation:
@@ -53,12 +50,6 @@ class TestStringRepresentation:
         document = suds.sax.parser.Parser().parse(suds.BytesIO(input_data))
         assert document.__class__ is Document
         return document
-
-    @pytest.mark.skipif(sys.version_info >= (3,), reason="Python 2 specific")
-    def test_convert_to_byte_str(self):
-        document = self.create_test_document()
-        expected = suds.byte_str(document.str())
-        assert str(document) == expected
 
     def test_convert_to_unicode(self):
         document = self.create_test_document()

--- a/tests/test_sax_document.py
+++ b/tests/test_sax_document.py
@@ -31,7 +31,6 @@ from suds.sax.document import Document
 import suds.sax.parser
 
 import pytest
-import six
 
 import re
 import sys
@@ -64,7 +63,7 @@ class TestStringRepresentation:
     def test_convert_to_unicode(self):
         document = self.create_test_document()
         expected = document.str()
-        assert six.text_type(document) == expected
+        assert str(document) == expected
 
     def test_plain_method(self):
         document = self.create_test_document()

--- a/tests/test_sax_element.py
+++ b/tests/test_sax_element.py
@@ -31,7 +31,6 @@ from suds.sax.element import Element
 import suds.sax.parser
 
 import pytest
-import six
 
 import re
 import sys
@@ -156,7 +155,7 @@ class TestStringRepresentation:
     def test_convert_to_unicode(self):
         element = self.create_test_element()
         expected = element.str()
-        assert six.text_type(element) == expected
+        assert str(element) == expected
 
     def test_plain_method(self):
         element = self.create_test_element(self.str_formatted_xml)

--- a/tests/test_sax_element.py
+++ b/tests/test_sax_element.py
@@ -33,7 +33,6 @@ import suds.sax.parser
 import pytest
 
 import re
-import sys
 
 
 class TestChildAtPath:
@@ -145,12 +144,6 @@ class TestStringRepresentation:
         element = xml.root()
         assert element.__class__ is Element
         return element
-
-    @pytest.mark.skipif(sys.version_info >= (3,), reason="Python 2 specific")
-    def test_convert_to_byte_str(self):
-        element = self.create_test_element()
-        expected = suds.byte_str(element.str())
-        assert str(element) == expected
 
     def test_convert_to_unicode(self):
         element = self.create_test_element()

--- a/tests/test_suds.py
+++ b/tests/test_suds.py
@@ -36,7 +36,6 @@ from suds.sax.text import Raw
 from testutils.compare_sax import CompareSAX
 
 import pytest
-from six import b, itervalues, next
 
 import re
 import xml.sax
@@ -44,7 +43,7 @@ import xml.sax
 
 @pytest.fixture
 def client_with_optional_array_parameters():
-    wsdl = b("""\
+    wsdl = b"""\
 <?xml version='1.0' encoding='UTF-8'?>
 <wsdl:definitions targetNamespace="my-namespace"
     xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
@@ -121,7 +120,7 @@ def client_with_optional_array_parameters():
     </wsdl:operation>
   </wsdl:binding>
 </wsdl:definitions>
-""")
+"""
 
     client = testutils.client_from_wsdl(wsdl, nosend=True, prettyxml=True)
 
@@ -179,12 +178,12 @@ def test_choice_parameter_implementation_inconsistencies():
 
 def test_converting_client_to_string_must_not_raise_an_exception():
     client = testutils.client_from_wsdl(
-        b("<?xml version='1.0' encoding='UTF-8'?><root/>"))
+        b"<?xml version='1.0' encoding='UTF-8'?><root/>")
     str(client)
 
 
 def test_converting_metadata_to_string():
-    client = testutils.client_from_wsdl(b("""\
+    client = testutils.client_from_wsdl(b"""\
 <?xml version='1.0' encoding='UTF-8'?>
 <wsdl:definitions targetNamespace="my-namespace"
     xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
@@ -215,7 +214,7 @@ def test_converting_metadata_to_string():
     </wsdl:port>
   </wsdl:service>
 </wsdl:definitions>
-"""))
+""")
     # Metadata with empty content.
     metadata = client.wsdl.__metadata__
     assert len(metadata) == 0
@@ -232,7 +231,7 @@ def test_converting_metadata_to_string():
 def test_empty_invalid_WSDL(monkeypatch):
     monkeypatch.delitem(locals(), "e", False)
     e = pytest.raises(xml.sax.SAXParseException, testutils.client_from_wsdl,
-        b(""))
+        b"")
     try:
         assert e.value.getMessage() == "no element found"
     finally:
@@ -241,13 +240,13 @@ def test_empty_invalid_WSDL(monkeypatch):
 
 def test_empty_valid_WSDL():
     client = testutils.client_from_wsdl(
-        b("<?xml version='1.0' encoding='UTF-8'?><root/>"))
+        b"<?xml version='1.0' encoding='UTF-8'?><root/>")
     assert not client.wsdl.services, "No service definitions must be read "  \
         "from an empty WSDL."
 
 
 def test_enumeration_type_string_should_contain_its_value():
-    client = testutils.client_from_wsdl(b("""\
+    client = testutils.client_from_wsdl(b"""\
 <?xml version='1.0' encoding='UTF-8'?>
 <wsdl:definitions targetNamespace="my-namespace"
     xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
@@ -278,7 +277,7 @@ def test_enumeration_type_string_should_contain_its_value():
     </wsdl:port>
   </wsdl:service>
 </wsdl:definitions>
-"""))
+""")
     enumeration_data = client.wsdl.schema.types["AAA", "my-namespace"]
     # Legend:
     #   eX - enumeration element.
@@ -300,7 +299,7 @@ def test_enumeration_type_string_should_contain_its_value():
 
 
 def test_function_parameters_global_sequence_in_a_sequence():
-    client = testutils.client_from_wsdl(b("""\
+    client = testutils.client_from_wsdl(b"""\
 <?xml version='1.0' encoding='UTF-8'?>
 <wsdl:definitions targetNamespace="my-namespace"
     xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
@@ -351,7 +350,7 @@ def test_function_parameters_global_sequence_in_a_sequence():
     </wsdl:port>
   </wsdl:service>
 </wsdl:definitions>
-"""))
+""")
 
     service = client.sd[0]
     assert len(service.types) == 1
@@ -384,7 +383,7 @@ def test_function_parameters_global_sequence_in_a_sequence():
 
 
 def test_function_parameters_local_choice():
-    client = testutils.client_from_wsdl(b("""\
+    client = testutils.client_from_wsdl(b"""\
 <?xml version='1.0' encoding='UTF-8'?>
 <wsdl:definitions targetNamespace="my-namespace"
     xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
@@ -427,7 +426,7 @@ def test_function_parameters_local_choice():
     </wsdl:port>
   </wsdl:service>
 </wsdl:definitions>
-"""))
+""")
 
     service = client.sd[0]
     assert not service.types
@@ -460,7 +459,7 @@ def test_function_parameters_local_choice():
 
 
 def test_function_parameters_local_choice_in_a_sequence():
-    client = testutils.client_from_wsdl(b("""\
+    client = testutils.client_from_wsdl(b"""\
 <?xml version='1.0' encoding='UTF-8'?>
 <wsdl:definitions targetNamespace="my-namespace"
     xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
@@ -512,7 +511,7 @@ def test_function_parameters_local_choice_in_a_sequence():
     </wsdl:port>
   </wsdl:service>
 </wsdl:definitions>
-"""))
+""")
 
     service = client.sd[0]
     assert not service.types
@@ -559,7 +558,7 @@ def test_function_parameters_local_choice_in_a_sequence():
 
 
 def test_function_parameters_local_sequence_in_a_sequence():
-    client = testutils.client_from_wsdl(b("""\
+    client = testutils.client_from_wsdl(b"""\
 <?xml version='1.0' encoding='UTF-8'?>
 <wsdl:definitions targetNamespace="my-namespace"
     xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
@@ -611,7 +610,7 @@ def test_function_parameters_local_sequence_in_a_sequence():
     </wsdl:port>
   </wsdl:service>
 </wsdl:definitions>
-"""))
+""")
 
     service = client.sd[0]
     assert not service.types
@@ -662,7 +661,7 @@ def test_function_parameters_local_sequence_in_a_sequence():
 
 
 def test_function_parameters_sequence_in_a_choice():
-    client = testutils.client_from_wsdl(b("""\
+    client = testutils.client_from_wsdl(b"""\
 <?xml version='1.0' encoding='UTF-8'?>
 <wsdl:definitions targetNamespace="my-namespace"
     xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
@@ -714,7 +713,7 @@ def test_function_parameters_sequence_in_a_choice():
     </wsdl:port>
   </wsdl:service>
 </wsdl:definitions>
-"""))
+""")
 
     # Input #1.
     request = _construct_SOAP_request(client, 'f', a1="Wackadoodle")
@@ -750,7 +749,7 @@ def test_function_parameters_sequence_in_a_choice():
 
 
 def test_function_parameters_sequence_in_a_choice_in_a_sequence():
-    client = testutils.client_from_wsdl(b("""\
+    client = testutils.client_from_wsdl(b"""\
 <?xml version='1.0' encoding='UTF-8'?>
 <wsdl:definitions targetNamespace="my-namespace"
     xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
@@ -808,7 +807,7 @@ def test_function_parameters_sequence_in_a_choice_in_a_sequence():
     </wsdl:port>
   </wsdl:service>
 </wsdl:definitions>
-"""))
+""")
 
     # Construct input parameters.
     param = client.factory.create("External.choice")
@@ -836,7 +835,7 @@ def test_function_parameters_sequence_in_a_choice_in_a_sequence():
 
 
 def test_function_parameters_strings():
-    client = testutils.client_from_wsdl(b("""\
+    client = testutils.client_from_wsdl(b"""\
 <?xml version='1.0' encoding='UTF-8'?>
 <wsdl:definitions targetNamespace="my-namespace"
     xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
@@ -880,7 +879,7 @@ def test_function_parameters_strings():
     </wsdl:port>
   </wsdl:service>
 </wsdl:definitions>
-"""))
+""")
 
     service = client.sd[0]
     assert not service.types
@@ -913,7 +912,7 @@ def test_function_parameters_strings():
 
 
 def test_global_enumeration():
-    client = testutils.client_from_wsdl(b("""\
+    client = testutils.client_from_wsdl(b"""\
 <?xml version='1.0' encoding='UTF-8'?>
 <wsdl:definitions targetNamespace="my-namespace"
     xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
@@ -944,7 +943,7 @@ def test_global_enumeration():
     </wsdl:port>
   </wsdl:service>
 </wsdl:definitions>
-"""))
+""")
 
     assert len(client.sd) == 1
     service = client.sd[0]
@@ -975,7 +974,7 @@ def test_global_enumeration():
 
 
 def test_global_sequence_in_a_global_sequence():
-    client = testutils.client_from_wsdl(b("""\
+    client = testutils.client_from_wsdl(b"""\
 <?xml version='1.0' encoding='UTF-8'?>
 <wsdl:definitions targetNamespace="my-namespace"
     xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
@@ -1013,7 +1012,7 @@ def test_global_sequence_in_a_global_sequence():
     </wsdl:port>
   </wsdl:service>
 </wsdl:definitions>
-"""))
+""")
 
     service = client.sd[0]
 
@@ -1060,7 +1059,7 @@ def test_global_sequence_in_a_global_sequence():
 
 
 def test_global_string_sequence():
-    client = testutils.client_from_wsdl(b("""\
+    client = testutils.client_from_wsdl(b"""\
 <?xml version='1.0' encoding='UTF-8'?>
 <wsdl:definitions targetNamespace="my-namespace"
     xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
@@ -1091,7 +1090,7 @@ def test_global_string_sequence():
     </wsdl:port>
   </wsdl:service>
 </wsdl:definitions>
-"""))
+""")
 
     service = client.sd[0]
 
@@ -1141,7 +1140,7 @@ def test_global_string_sequence():
 
 
 def test_local_sequence_in_a_global_sequence():
-    client = testutils.client_from_wsdl(b("""\
+    client = testutils.client_from_wsdl(b"""\
 <?xml version='1.0' encoding='UTF-8'?>
 <wsdl:definitions targetNamespace="my-namespace"
     xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
@@ -1185,7 +1184,7 @@ def test_local_sequence_in_a_global_sequence():
     </wsdl:port>
   </wsdl:service>
 </wsdl:definitions>
-"""))
+""")
 
     service = client.sd[0]
     assert len(service.types) == 1
@@ -1231,7 +1230,7 @@ def test_local_sequence_in_a_global_sequence():
 
 
 def test_optional_parameter_not_instantiated():
-    wsdl = b("""\
+    wsdl = b"""\
 <?xml version='1.0' encoding='UTF-8'?>
 <wsdl:definitions targetNamespace="my-namespace"
     xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
@@ -1309,7 +1308,7 @@ def test_optional_parameter_not_instantiated():
     </wsdl:operation>
   </wsdl:binding>
 </wsdl:definitions>
-""")
+"""
 
     expected_request_content = """\
 <?xml version="1.0" encoding="UTF-8"?>
@@ -1416,7 +1415,7 @@ def test_empty_optional_array_is_not_present(client_with_optional_array_paramete
 
 
 def test_named_parameter_with_underscore():
-    client = testutils.client_from_wsdl(b("""\
+    client = testutils.client_from_wsdl(b"""\
 <?xml version="1.0" encoding="utf-8"?>
 <wsdl:definitions xmlns:s="http://www.w3.org/2001/XMLSchema" xmlns:soap12="http://schemas.xmlsoap.org/wsdl/soap12/" xmlns:http="http://schemas.xmlsoap.org/wsdl/http/" xmlns:mime="http://schemas.xmlsoap.org/wsdl/mime/" xmlns:tns="https://labelservice.gls-italy.com/" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:tm="http://microsoft.com/wsdl/mime/textMatching/" xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/" targetNamespace="https://labelservice.gls-italy.com/" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">
   <wsdl:types>
@@ -1545,7 +1544,7 @@ def test_named_parameter_with_underscore():
     </wsdl:port>
   </wsdl:service>
 </wsdl:definitions>
-"""), nosend=True, prettyxml=True)
+""", nosend=True, prettyxml=True)
     xml = Raw("""
     <info>
       <SedeGls>XX</SedeGls>
@@ -1580,7 +1579,7 @@ def test_named_parameter_with_underscore():
 
 
 def test_attributes_on_elements():
-    client = testutils.client_from_wsdl(b("""\
+    client = testutils.client_from_wsdl(b"""\
 <?xml version='1.0' encoding='UTF-8'?>
 <wsdl:definitions targetNamespace="my-namespace"
     xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
@@ -1632,7 +1631,7 @@ def test_attributes_on_elements():
     </wsdl:operation>
   </wsdl:binding>
 </wsdl:definitions>
-"""), nosend=True)
+""", nosend=True)
     foobar = client.factory.create("foobar")
 
     assert foobar.value is None
@@ -1657,7 +1656,7 @@ def test_attributes_on_elements():
     _assert_request_content(result, expected_request_content)
 
 def test_no_trailing_comma_in_function_prototype_description_string__0():
-    client = testutils.client_from_wsdl(b("""\
+    client = testutils.client_from_wsdl(b"""\
 <?xml version='1.0' encoding='UTF-8'?>
 <wsdl:definitions targetNamespace="my-namespace"
     xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
@@ -1697,13 +1696,13 @@ def test_no_trailing_comma_in_function_prototype_description_string__0():
     </wsdl:port>
   </wsdl:service>
 </wsdl:definitions>
-"""))
+""")
     s = str(client)
     assert " f()\n" in s
 
 
 def test_no_trailing_comma_in_function_prototype_description_string__1():
-    client = testutils.client_from_wsdl(b("""\
+    client = testutils.client_from_wsdl(b"""\
 <?xml version='1.0' encoding='UTF-8'?>
 <wsdl:definitions targetNamespace="my-namespace"
     xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
@@ -1745,13 +1744,13 @@ def test_no_trailing_comma_in_function_prototype_description_string__1():
     </wsdl:port>
   </wsdl:service>
 </wsdl:definitions>
-"""))
+""")
     s = str(client)
     assert " f(xs:string x1)\n" in s
 
 
 def test_no_trailing_comma_in_function_prototype_description_string__3():
-    client = testutils.client_from_wsdl(b("""\
+    client = testutils.client_from_wsdl(b"""\
 <?xml version='1.0' encoding='UTF-8'?>
 <wsdl:definitions targetNamespace="my-namespace"
     xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
@@ -1795,13 +1794,13 @@ def test_no_trailing_comma_in_function_prototype_description_string__3():
     </wsdl:port>
   </wsdl:service>
 </wsdl:definitions>
-"""))
+""")
     s = str(client)
     assert " f(xs:string x1, xs:string x2, xs:string x3)\n" in s
 
 
 def test_no_types():
-    client = testutils.client_from_wsdl(b("""\
+    client = testutils.client_from_wsdl(b"""\
 <?xml version='1.0' encoding='UTF-8'?>
 <wsdl:definitions targetNamespace="my-namespace"
     xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
@@ -1824,7 +1823,7 @@ def test_no_types():
     </wsdl:port>
   </wsdl:service>
 </wsdl:definitions>
-"""))
+""")
 
     assert len(client.sd) == 1
     service = client.sd[0]
@@ -1850,7 +1849,7 @@ class TestFindTypeInXSDSchemaWithRecursiveTypeDefinitions:
     """Must not cause an infinite loop."""
 
     def test_with_recursion_in_imported_schema(self):
-        client = testutils.client_from_wsdl(b("""\
+        client = testutils.client_from_wsdl(b"""\
 <?xml version='1.0' encoding='UTF-8'?>
 <wsdl:definitions targetNamespace="my-namespace"
     xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
@@ -1892,12 +1891,12 @@ class TestFindTypeInXSDSchemaWithRecursiveTypeDefinitions:
     </wsdl:port>
   </wsdl:service>
 </wsdl:definitions>
-"""))
+""")
         assert pytest.raises(
             suds.TypeNotFound, client.factory.create, 'ns:DoesNotExist')
 
     def test_with_recursion_in_same_schema(self):
-        client = testutils.client_from_wsdl(b("""\
+        client = testutils.client_from_wsdl(b"""\
 <?xml version='1.0' encoding='UTF-8'?>
 <wsdl:definitions targetNamespace="my-namespace"
     xmlns:ns="my-namespace"
@@ -1928,25 +1927,25 @@ class TestFindTypeInXSDSchemaWithRecursiveTypeDefinitions:
     </wsdl:port>
   </wsdl:service>
 </wsdl:definitions>
-"""))
+""")
         assert pytest.raises(
             suds.TypeNotFound, client.factory.create, 'ns:DoesNotExist')
 
 
 def test_recursive_XSD_import():
     url_xsd = "suds://xsd"
-    xsd = b("""\
+    xsd = f"""\
 <xsd:schema targetNamespace="my-xsd-namespace"
     xmlns:xsd="http://www.w3.org/2001/XMLSchema">
-  <xsd:import namespace="my-xsd-namespace" schemaLocation="%(url_imported)s"/>
+  <xsd:import namespace="my-xsd-namespace" schemaLocation="{url_xsd}"/>
 </xsd:schema>
-""" % dict(url_imported=url_xsd))
-    wsdl = b("""\
+""".encode()
+    wsdl = f"""\
 <?xml version='1.0' encoding='UTF-8'?>
 <wsdl:definitions targetNamespace="my-wsdl-namespace"
     xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">
-  <wsdl:import location="%(url_imported)s"/>
-</wsdl:definitions>""" % dict(url_imported=url_xsd))
+  <wsdl:import location="{url_xsd}"/>
+</wsdl:definitions>""".encode()
     store = suds.store.DocumentStore(xsd=xsd)
     testutils.client_from_wsdl(wsdl, documentStore=store)
 
@@ -2029,7 +2028,7 @@ def test_restrictions():
 
 
 def test_schema_node_occurrences():
-    client = testutils.client_from_wsdl(b("""\
+    client = testutils.client_from_wsdl(("""\
 <?xml version='1.0' encoding='UTF-8'?>
 <wsdl:definitions targetNamespace="my-namespace"
     xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
@@ -2066,7 +2065,7 @@ def test_schema_node_occurrences():
     </xsd:schema>
   </wsdl:types>
 </wsdl:definitions>
-"""))
+""").encode())
     schema = client.wsdl.schema
 
     def a(schema, name, min=None, max=None):
@@ -2117,7 +2116,7 @@ def test_schema_node_occurrences():
 
 
 def test_schema_node_resolve():
-    client = testutils.client_from_wsdl(b("""\
+    client = testutils.client_from_wsdl(b"""\
 <?xml version='1.0' encoding='UTF-8'?>
 <wsdl:definitions targetNamespace="my-namespace"
     xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
@@ -2154,7 +2153,7 @@ def test_schema_node_resolve():
     </xsd:schema>
   </wsdl:types>
 </wsdl:definitions>
-"""))
+""")
     schema = client.wsdl.schema
 
     # Collect references to the test schema type nodes.
@@ -2197,7 +2196,7 @@ def test_schema_node_resolve():
 
 
 def test_schema_node_resolve__nobuiltin_caching():
-    client = testutils.client_from_wsdl(b("""\
+    client = testutils.client_from_wsdl(b"""\
 <?xml version='1.0' encoding='UTF-8'?>
 <wsdl:definitions targetNamespace="my-namespace"
     xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
@@ -2214,7 +2213,7 @@ def test_schema_node_resolve__nobuiltin_caching():
     </xsd:schema>
   </wsdl:types>
 </wsdl:definitions>
-"""))
+""")
     schema = client.wsdl.schema
 
     # Collect references to the test schema element nodes.
@@ -2244,7 +2243,7 @@ def test_schema_node_resolve__nobuiltin_caching():
 
 
 def test_schema_node_resolve__invalid_type():
-    client = testutils.client_from_wsdl(b("""\
+    client = testutils.client_from_wsdl(b"""\
 <?xml version='1.0' encoding='UTF-8'?>
 <wsdl:definitions targetNamespace="my-namespace"
     xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
@@ -2260,7 +2259,7 @@ def test_schema_node_resolve__invalid_type():
     </xsd:schema>
   </wsdl:types>
 </wsdl:definitions>
-"""))
+""")
     schema = client.wsdl.schema
     assert len(schema.elements) == 3
     elemento1 = schema.elements["Elemento1", "my-namespace"]
@@ -2272,7 +2271,7 @@ def test_schema_node_resolve__invalid_type():
 
 
 def test_schema_node_resolve__references():
-    client = testutils.client_from_wsdl(b("""\
+    client = testutils.client_from_wsdl(b"""\
 <?xml version='1.0' encoding='UTF-8'?>
 <wsdl:definitions targetNamespace="my-namespace"
     xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
@@ -2302,7 +2301,7 @@ def test_schema_node_resolve__references():
     </xsd:schema>
   </wsdl:types>
 </wsdl:definitions>
-"""))
+""")
     schema = client.wsdl.schema
 
     # Collect references to the test schema element & type nodes.
@@ -2348,7 +2347,7 @@ def test_schema_node_resolve__references():
 
 
 def test_schema_object_child_access_by_index():
-    client = testutils.client_from_wsdl(b("""\
+    client = testutils.client_from_wsdl(b"""\
 <?xml version='1.0' encoding='UTF-8'?>
 <wsdl:definitions targetNamespace="my-namespace"
     xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
@@ -2379,7 +2378,7 @@ def test_schema_object_child_access_by_index():
     </wsdl:port>
   </wsdl:service>
 </wsdl:definitions>
-"""))
+""")
 
     service = client.sd[0]
     a_type = service.types[0][0]
@@ -2416,7 +2415,7 @@ def test_schema_object_child_access_by_index():
 
 
 def test_simple_wsdl():
-    client = testutils.client_from_wsdl(b("""\
+    client = testutils.client_from_wsdl(b"""\
 <?xml version='1.0' encoding='UTF-8'?>
 <wsdl:definitions targetNamespace="my-namespace"
     xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
@@ -2470,7 +2469,7 @@ def test_simple_wsdl():
     </wsdl:port>
   </wsdl:service>
 </wsdl:definitions>
-"""))
+""")
 
     # Target namespace.
     assert client.wsdl.tns[0] == "ns"
@@ -2525,7 +2524,7 @@ def test_simple_wsdl():
     assert binding_qname == ("dummy", "my-namespace")
     assert binding.__class__ is suds.wsdl.Binding
     assert len(binding.operations) == 1
-    operation = next(itervalues(binding.operations))
+    operation = next(iter(binding.operations.values()))
     input = operation.soap.input.body
     output = operation.soap.output.body
     assert len(input.parts) == 1
@@ -2562,7 +2561,7 @@ def test_simple_wsdl():
 
 
 def test_wsdl_schema_content():
-    client = testutils.client_from_wsdl(b("""\
+    client = testutils.client_from_wsdl(b"""\
 <?xml version='1.0' encoding='UTF-8'?>
 <wsdl:definitions targetNamespace="my-namespace"
     xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
@@ -2603,7 +2602,7 @@ def test_wsdl_schema_content():
     </xsd:schema>
   </wsdl:types>
 </wsdl:definitions>
-"""))
+""")
 
     # Elements.
     assert len(client.wsdl.schema.elements) == 1

--- a/tests/test_suds.py
+++ b/tests/test_suds.py
@@ -289,13 +289,9 @@ def test_enumeration_type_string_should_contain_its_value():
     assert e1.name == "One"
     assert e2.name == "Two"
     assert e3.name == "Thirty-Two"
-    # Python 3 output does not include a trailing L after long integer output,
-    # while Python 2 does. For example: 0x12345678 is output as 0x12345678L in
-    # Python 2 and simply as 0x12345678 in Python 3.
-    assert re.match('<Enumeration:0x[0-9a-f]+L? name="One" />$', e1.str())
-    assert re.match('<Enumeration:0x[0-9a-f]+L? name="Two" />$', e2.str())
-    assert re.match('<Enumeration:0x[0-9a-f]+L? name="Thirty-Two" />$',
-        e3.str())
+    assert re.match('<Enumeration:0x[0-9a-f]+ name="One" />$', e1.str())
+    assert re.match('<Enumeration:0x[0-9a-f]+ name="Two" />$', e2.str())
+    assert re.match('<Enumeration:0x[0-9a-f]+ name="Thirty-Two" />$', e3.str())
 
 
 def test_function_parameters_global_sequence_in_a_sequence():

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -31,7 +31,6 @@ from suds.transport import Reply, Request, Transport
 import suds.transport.options
 
 import pytest
-from six import b, text_type, u, unichr
 
 import sys
 
@@ -59,18 +58,18 @@ class TestReply:
 
     @pytest.mark.parametrize(("code", "headers", "message"), (
         (1, {}, None),
-        (1, {}, u("ola")),
-        (1, {}, b("ola")),
+        (1, {}, "ola"),
+        (1, {}, b"ola"),
         (1, {}, object()),
-        (1, {}, u("\u0161u\u0107-mu\u0107 \u4E2D\u539F\u5343\n\u57CE")),
-        (2, {"semper": "fi"}, u("\u4E2D\u539F\u5343\n\u57CE"))))
+        (1, {}, "\u0161u\u0107-mu\u0107 \u4E2D\u539F\u5343\n\u57CE"),
+        (2, {"semper": "fi"}, "\u4E2D\u539F\u5343\n\u57CE")))
     def test_construction(self, code, headers, message):
         reply = Reply(code, headers, message)
         assert reply.code is code
         assert reply.headers is headers
         assert reply.message is message
 
-    @pytest.mark.parametrize("message", [u(x).encode("utf-8") for x in (
+    @pytest.mark.parametrize("message", [x.encode() for x in (
         "",
         "for a bitch it's haaaard...",
         """\
@@ -84,12 +83,12 @@ and I'm all out of gum.""",
     def test_string_representation(self, message):
         code = 17
         reply = Reply(code, {"aaa": 1}, message)
-        expected = u("""\
+        expected = """\
 CODE: %s
 HEADERS: %s
 MESSAGE:
-%s""") % (code, reply.headers, message.decode("raw_unicode_escape"))
-        assert text_type(reply) == expected
+%s""" % (code, reply.headers, message.decode("raw_unicode_escape"))
+        assert str(reply) == expected
         if sys.version_info < (3,):
             assert str(reply) == expected.encode("utf-8")
 
@@ -99,7 +98,7 @@ class TestRequest:
     @pytest.mark.parametrize("message", (
         None,
         "it's hard out here...",
-        u("\u57CE\u697C\u4E07\u4F17\u68C0\u9605")))
+        "\u57CE\u697C\u4E07\u4F17\u68C0\u9605"))
     def test_construct(self, message):
         # Always use the same URL as different ways to specify a Request's URL
         # are tested separately.
@@ -117,14 +116,14 @@ class TestRequest:
         assert request.message is None
 
     test_non_ASCII_URLs = [
-        u("\u4E2D\u539F\u5343\u519B\u9010\u848B"),
-        u("\u57CE\u697C\u4E07\u4F17\u68C0\u9605")] + [
+        "\u4E2D\u539F\u5343\u519B\u9010\u848B",
+        "\u57CE\u697C\u4E07\u4F17\u68C0\u9605"] + [
         url_prefix + url_suffix
-            for url_prefix in (u(""), u("Jurko"))
-            for url_suffix in (unichr(128), unichr(200), unichr(1000))]
+            for url_prefix in ("", "Jurko")
+            for url_suffix in (chr(128), chr(200), chr(1000))]
     @pytest.mark.parametrize("url",
         test_non_ASCII_URLs +  # unicode strings
-        [x.encode("utf-8") for x in test_non_ASCII_URLs])  # byte strings
+        [x.encode() for x in test_non_ASCII_URLs])  # byte strings
     def test_non_ASCII_URL(self, url):
         """Transport Request should reject URLs with non-ASCII characters."""
         pytest.raises(UnicodeError, Request, url)
@@ -137,29 +136,29 @@ class TestRequest:
 I'm here to kick ass,
 and chew bubble gum...
 and I'm all out of gum."""),
-        ("", {}, u("\u0161u\u0107-mu\u0107 pa o\u017Ee\u017Ei.. za 100 "
-            "\u20AC\n\nwith multiple\nlines...")),
+        ("", {}, "\u0161u\u0107-mu\u0107 pa o\u017Ee\u017Ei.. za 100 "
+            "\u20AC\n\nwith multiple\nlines..."),
         ("", {}, "\n\n\n\n\n\n"),
-        ("", {}, u("\u4E2D\u539F\u5343\u519B\u9010\u848B"))))
+        ("", {}, "\u4E2D\u539F\u5343\u519B\u9010\u848B")))
     def test_string_representation_with_message(self, url, headers, message):
         for key, value in list(headers.items()):
             old_key = key
-            if isinstance(key, text_type):
-                key = key.encode("utf-8")
+            if isinstance(key, str):
+                key = key.encode()
                 del headers[old_key]
-            if isinstance(value, text_type):
-                value = value.encode("utf-8")
+            if isinstance(value, str):
+                value = value.encode()
             headers[key] = value
-        if isinstance(message, text_type):
-            message = message.encode("utf-8")
+        if isinstance(message, str):
+            message = message.encode()
         request = Request(url, message)
         request.headers = headers
-        expected = u("""\
+        expected = """\
 URL: %s
 HEADERS: %s
 MESSAGE:
-%s""") % (url, request.headers, message.decode("raw_unicode_escape"))
-        assert text_type(request) == expected
+%s""" % (url, request.headers, message.decode("raw_unicode_escape"))
+        assert str(request) == expected
         if sys.version_info < (3,):
             assert str(request) == expected.encode("utf-8")
 
@@ -168,21 +167,21 @@ MESSAGE:
         headers = {suds.byte_str("yuck"): suds.byte_str("ptooiii...")}
         request = Request(url)
         request.headers = headers
-        expected = u("""\
+        expected = """\
 URL: %s
-HEADERS: %s""") % (url, request.headers)
-        assert text_type(request) == expected
+HEADERS: %s""" % (url, request.headers)
+        assert str(request) == expected
         if sys.version_info < (3,):
             assert str(request) == expected.encode("utf-8")
 
     test_URLs = [
-        u(""),
-        u("http://host/path/name"),
-        u("cogito://ergo/sum"),
-        u("haleluya"),
-        u("look  at  me flyyyyyyyy"),
-        unichr(127),
-        u("Jurko") + unichr(127)]
+        "",
+        "http://host/path/name",
+        "cogito://ergo/sum",
+        "haleluya",
+        "look  at  me flyyyyyyyy",
+        chr(127),
+        "Jurko" + chr(127)]
     @pytest.mark.parametrize("url", test_URLs + [
         url.encode("ascii") for url in test_URLs])
     def test_URL(self, url):
@@ -196,12 +195,10 @@ HEADERS: %s""") % (url, request.headers)
         assert isinstance(request.url, str)
         if url.__class__ is str:
             assert request.url is url
-        elif url.__class__ is u:
-            assert request.url == url.encode("ascii")  # Python 2.
         else:
-            assert request.url == url.decode("ascii")  # Python 3.
+            assert request.url == url.decode("ascii")
 
-    test_URLs = [unichr(0), u("Jurko") + unichr(0)] if sys.version_info <= (3, 6) else []  # "https://bugs.python.org/issue32745"
+    test_URLs = [chr(0), "Jurko" + chr(0)] if sys.version_info <= (3, 6) else []  # "https://bugs.python.org/issue32745"
     @pytest.mark.parametrize("url", test_URLs + [
         url.encode("ascii") for url in test_URLs])
     def test_URL_null_bytes(self, url):
@@ -215,7 +212,5 @@ HEADERS: %s""") % (url, request.headers)
         assert isinstance(request.url, str)
         if url.__class__ is str:
             assert request.url is url
-        elif url.__class__ is u:
-            assert request.url == url.encode("ascii")  # Python 2.
         else:
-            assert request.url == url.decode("ascii")  # Python 3.
+            assert request.url == url.decode("ascii")

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -89,8 +89,6 @@ HEADERS: %s
 MESSAGE:
 %s""" % (code, reply.headers, message.decode("raw_unicode_escape"))
         assert str(reply) == expected
-        if sys.version_info < (3,):
-            assert str(reply) == expected.encode("utf-8")
 
 
 class TestRequest:
@@ -159,8 +157,6 @@ HEADERS: %s
 MESSAGE:
 %s""" % (url, request.headers, message.decode("raw_unicode_escape"))
         assert str(request) == expected
-        if sys.version_info < (3,):
-            assert str(request) == expected.encode("utf-8")
 
     def test_string_representation_with_no_message(self):
         url = "look at my silly little URL"
@@ -171,8 +167,6 @@ MESSAGE:
 URL: %s
 HEADERS: %s""" % (url, request.headers)
         assert str(request) == expected
-        if sys.version_info < (3,):
-            assert str(request) == expected.encode("utf-8")
 
     test_URLs = [
         "",

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -198,7 +198,7 @@ HEADERS: %s""" % (url, request.headers)
         else:
             assert request.url == url.decode("ascii")
 
-    test_URLs = [chr(0), "Jurko" + chr(0)] if sys.version_info <= (3, 6) else []  # "https://bugs.python.org/issue32745"
+    test_URLs = [chr(0), "Jurko" + chr(0)] if sys.version_info >= (3, 8) else []  # "https://bugs.python.org/issue32745"
     @pytest.mark.parametrize("url", test_URLs + [
         url.encode("ascii") for url in test_URLs])
     def test_URL_null_bytes(self, url):

--- a/tests/test_transport_http.py
+++ b/tests/test_transport_http.py
@@ -31,15 +31,14 @@ import suds.transport
 import suds.transport.http
 
 import pytest
-from six import u
-from six.moves import http_client
-from six.moves.urllib.error import HTTPError
-from six.moves.urllib.request import ProxyHandler
 
 import base64
+import http.client
 import re
 import sys
 from email.message import Message
+from urllib.error import HTTPError
+from urllib.request import ProxyHandler
 
 # We can not use six.moves modules for this since we want to monkey-patch the
 # exact underlying urllib2/urllib.request module in our tests and not just
@@ -180,7 +179,7 @@ def assert_default_transport(transport):
     assert transport.urlopener is None
 
 
-def create_request(url="protocol://default-url", data=u("Rumpelstiltskin")):
+def create_request(url="protocol://default-url", data="Rumpelstiltskin"):
     """Test utility constructing a suds.transport.Request instance."""
     return suds.transport.Request(url, data)
 
@@ -336,7 +335,7 @@ def test_sending_using_network_sockets(send_method, monkeypatch):
     url_relative = "svc"
     url = "http://%s/%s" % (host_port, url_relative)
     partial_ascii_byte_data = suds.byte_str("Muka-laka-hiki")
-    non_ascii_byte_data = u("\u0414\u043C\u0438 \u0442\u0440").encode("utf-8")
+    non_ascii_byte_data = "\u0414\u043C\u0438 \u0442\u0440".encode()
     non_ascii_byte_data += partial_ascii_byte_data
     mocker = Mocker(host, port)
     monkeypatch.setattr("socket.getaddrinfo", mocker.getaddrinfo)
@@ -372,7 +371,7 @@ def test_sending_using_network_sockets(send_method, monkeypatch):
         expected_sent_data_start, url_relative)
     expected_sent_data_start = suds.byte_str(expected_sent_data_start)
     assert mocker.mock_sent_data.startswith(expected_sent_data_start)
-    assert host_port.encode("utf-8") in mocker.mock_sent_data
+    assert host_port.encode() in mocker.mock_sent_data
     if expected_request_data_send:
         assert mocker.mock_sent_data.endswith(non_ascii_byte_data)
     else:
@@ -448,17 +447,17 @@ class TestURLOpenerUsage:
         return HTTPError(url=url, code=code, msg=msg, hdrs=hdrs, fp=fp)
 
     @pytest.mark.parametrize("status_code", (
-        http_client.ACCEPTED,
-        http_client.NO_CONTENT,
-        http_client.RESET_CONTENT,
-        http_client.MOVED_PERMANENTLY,
-        http_client.BAD_REQUEST,
-        http_client.PAYMENT_REQUIRED,
-        http_client.FORBIDDEN,
-        http_client.NOT_FOUND,
-        http_client.INTERNAL_SERVER_ERROR,
-        http_client.NOT_IMPLEMENTED,
-        http_client.HTTP_VERSION_NOT_SUPPORTED))
+        http.client.ACCEPTED,
+        http.client.NO_CONTENT,
+        http.client.RESET_CONTENT,
+        http.client.MOVED_PERMANENTLY,
+        http.client.BAD_REQUEST,
+        http.client.PAYMENT_REQUIRED,
+        http.client.FORBIDDEN,
+        http.client.NOT_FOUND,
+        http.client.INTERNAL_SERVER_ERROR,
+        http.client.NOT_IMPLEMENTED,
+        http.client.HTTP_VERSION_NOT_SUPPORTED))
     def test_open_propagating_HTTPError_exceptions(self, status_code,
             monkeypatch):
         """
@@ -486,8 +485,8 @@ class TestURLOpenerUsage:
 
     @pytest.mark.xfail(reason="original suds library bug")
     @pytest.mark.parametrize("status_code", (
-        http_client.ACCEPTED,
-        http_client.NO_CONTENT))
+        http.client.ACCEPTED,
+        http.client.NO_CONTENT))
     def test_operation_invoke_with_urlopen_accept_no_content__data(self,
             status_code):
         """
@@ -507,8 +506,8 @@ class TestURLOpenerUsage:
 
     @pytest.mark.xfail(reason="original suds library bug")
     @pytest.mark.parametrize("status_code", (
-        http_client.ACCEPTED,
-        http_client.NO_CONTENT))
+        http.client.ACCEPTED,
+        http.client.NO_CONTENT))
     def test_operation_invoke_with_urlopen_accept_no_content__no_data(self,
             status_code):
         """
@@ -545,15 +544,15 @@ class TestURLOpenerUsage:
         assert pytest.raises(e.__class__, t.open, create_request()).value is e
 
     @pytest.mark.parametrize("status_code", (
-        http_client.RESET_CONTENT,
-        http_client.MOVED_PERMANENTLY,
-        http_client.BAD_REQUEST,
-        http_client.PAYMENT_REQUIRED,
-        http_client.FORBIDDEN,
-        http_client.NOT_FOUND,
-        http_client.INTERNAL_SERVER_ERROR,
-        http_client.NOT_IMPLEMENTED,
-        http_client.HTTP_VERSION_NOT_SUPPORTED))
+        http.client.RESET_CONTENT,
+        http.client.MOVED_PERMANENTLY,
+        http.client.BAD_REQUEST,
+        http.client.PAYMENT_REQUIRED,
+        http.client.FORBIDDEN,
+        http.client.NOT_FOUND,
+        http.client.INTERNAL_SERVER_ERROR,
+        http.client.NOT_IMPLEMENTED,
+        http.client.HTTP_VERSION_NOT_SUPPORTED))
     def test_send_transforming_HTTPError_exceptions(self, status_code,
             monkeypatch):
         """
@@ -583,8 +582,8 @@ class TestURLOpenerUsage:
             del e  # explicitly break circular reference chain in Python 3
 
     @pytest.mark.parametrize("status_code", (
-        http_client.ACCEPTED,
-        http_client.NO_CONTENT))
+        http.client.ACCEPTED,
+        http.client.NO_CONTENT))
     def test_send_transforming_HTTPError_exceptions__accepted_no_content(self,
             status_code):
         """

--- a/tests/test_wsse.py
+++ b/tests/test_wsse.py
@@ -1,5 +1,4 @@
 import pytest
-from six import b, itervalues, next
 
 import testutils
 if __name__ == "__main__":

--- a/tests/test_xsd_builtins.py
+++ b/tests/test_xsd_builtins.py
@@ -36,15 +36,11 @@ import pytest
 
 import datetime
 import decimal
+import fractions
 import re
 import sys
 
-if sys.version_info >= (2, 6):
-    import fractions
-if sys.version_info >= (3,):
-    long = int
-
-
+    
 class _Dummy:
     """Class for testing unknown object class handling."""
     pass
@@ -164,10 +160,6 @@ class TestXBoolean:
 
     @pytest.mark.parametrize("source", (
         None,
-        pytest.mark.skipif(sys.version_info >= (3,),
-            reason="int == long since Python 3.0")(long(0)),
-        pytest.mark.skipif(sys.version_info >= (3,),
-            reason="int == long since Python 3.0")(long(1)),
         "x",
         "True",
         "False",
@@ -315,12 +307,10 @@ class TestXDecimal:
         assert translated.__class__ is str
         assert translated == expected
 
-    extra_test_data = ()
-    if sys.version_info >= (2, 6):
-        extra_test_data = (
-            # fraction.Fraction
-            fractions.Fraction(10, 4),
-            fractions.Fraction(1, 3))
+    extra_test_data = (
+        # fraction.Fraction
+        fractions.Fraction(10, 4),
+        fractions.Fraction(1, 3))
     @pytest.mark.parametrize("source", (
         None,
         # bool
@@ -383,12 +373,10 @@ class TestXDecimal:
 class TestXFloat:
     """suds.xsd.sxbuiltin.XFloat.translate() tests."""
 
-    extra_test_data = ()
-    if sys.version_info >= (2, 6):
-        extra_test_data = (
-            # fraction.Fraction
-            fractions.Fraction(10, 4),
-            fractions.Fraction(1, 3))
+    extra_test_data = (
+        # fraction.Fraction
+        fractions.Fraction(10, 4),
+        fractions.Fraction(1, 3))
     @pytest.mark.parametrize("source", (
         None,
         # bool
@@ -475,11 +463,6 @@ class TestXInteger:
         0,
         1,
         50,
-        # long
-        long(-50),
-        long(0),
-        long(1),
-        long(50),
         # str
         "x",
         # other
@@ -535,11 +518,6 @@ class TestXLong:
         0,
         1,
         50,
-        # long
-        long(-50),
-        long(0),
-        long(1),
-        long(50),
         # str
         "x",
         # other
@@ -558,7 +536,7 @@ class TestXLong:
         ("100", 100)))
     def test_to_python_object(self, source, expected):
         translated = MockXLong().translate(source)
-        assert translated.__class__ is long
+        assert translated.__class__ is int
         assert translated == expected
 
     @pytest.mark.parametrize("source",
@@ -570,7 +548,7 @@ class TestXLong:
     def test_to_python_object__invalid_string(self, source, monkeypatch):
         """
         Suds raises raw Python exceptions when it fails to convert received
-        response element data to its mapped Python long data type, according to
+        response element data to its mapped Python int data type, according to
         the used WSDL schema.
 
         """
@@ -580,7 +558,7 @@ class TestXLong:
             # Using different Python interpreter versions and different source
             # strings results in different exception messages here.
             try:
-                long(source)
+                int(source)
                 pytest.fail("Bad test data.")
             except ValueError:
                 assert str(e) == str(sys.exc_info()[1])

--- a/tests/test_xsd_element.py
+++ b/tests/test_xsd_element.py
@@ -34,7 +34,6 @@ import suds.store
 import suds.xsd.schema
 
 import pytest
-from six import b
 
 
 # shared test input data
@@ -70,7 +69,7 @@ class TestElementForm:
             "parent_name": parent_name}
         expected = form == "qualified" or (
             (form is None) and (form_default == "qualified"))
-        schema = _parse_schema_xml(b(schema_xml))
+        schema = _parse_schema_xml(schema_xml.encode())
         parent_element = schema.elements[parent_name, namespace]
         element = parent_element.get_child(element_name)[0]
         assert bool(element.form_qualified) == expected
@@ -104,7 +103,7 @@ class TestElementForm:
             "namespace": namespace,
             "referenced_name": referenced_name,
             "referencing_parent_name": referencing_parent_name}
-        schema = _parse_schema_xml(b(schema_xml))
+        schema = _parse_schema_xml(schema_xml.encode())
         parent_element = schema.elements[referencing_parent_name, namespace]
         referencing_element = parent_element.get_child(referenced_name)[0]
         assert referencing_element.form_qualified
@@ -128,8 +127,8 @@ class TestElementForm:
 <schema xmlns="http://www.w3.org/2001/XMLSchema" targetNamespace="ns-there">
     <element name="Referenced"/>
 </schema>"""
-        store = suds.store.DocumentStore({"there.xsd": b(schema_xml_there)})
-        schema = _parse_schema_xml(b(schema_xml_here), store)
+        store = suds.store.DocumentStore({"there.xsd": schema_xml_there.encode()})
+        schema = _parse_schema_xml(schema_xml_here.encode(), store)
         referenced_element = schema.elements["Referenced", "ns-there"]
         referencing_parent = schema.elements["Referencing", None]
         referencing_element = referencing_parent.get_child("Referenced")[0]
@@ -151,7 +150,7 @@ class TestElementForm:
             "form": _attribute_xml("form", form),
             "form_default": _attribute_xml("elementFormDefault", form_default),
             "namespace": namespace}
-        schema = _parse_schema_xml(b(schema_xml))
+        schema = _parse_schema_xml(schema_xml.encode())
         element = schema.elements[element_name, namespace]
         assert element.form_qualified
 
@@ -175,8 +174,8 @@ def test_reference():
 <schema xmlns="http://www.w3.org/2001/XMLSchema" targetNamespace="ns-there">
     <element name="Referenced"/>
 </schema>"""
-    store = suds.store.DocumentStore({"there.xsd": b(schema_xml_there)})
-    schema = _parse_schema_xml(b(schema_xml_here), store)
+    store = suds.store.DocumentStore({"there.xsd": schema_xml_there.encode()})
+    schema = _parse_schema_xml(schema_xml_here.encode(), store)
     referenced_element = schema.elements["Referenced", "ns-there"]
     referencing_parent = schema.elements["Referencing", None]
     referencing_element = referencing_parent.get_child("Referenced")[0]

--- a/tests/testutils/__init__.py
+++ b/tests/testutils/__init__.py
@@ -23,8 +23,6 @@ Package containing different utilities used for suds project testing.
 import suds.client
 import suds.store
 
-import six
-
 import os
 import subprocess
 import sys
@@ -159,7 +157,7 @@ def wsdl(schema_content, input=None, output=None, operation_name="f",
         name.
 
     """
-    assert isinstance(schema_content, six.string_types)
+    assert isinstance(schema_content, str)
 
     has_input = input is not None
     has_output = output is not None

--- a/tests/testutils/__init__.py
+++ b/tests/testutils/__init__.py
@@ -88,12 +88,10 @@ if suds.__version__ != %(suds.__version__)r:
     print("Unexpected suds version imported - '%%s'." %% (suds.__version__))
     sys.exit(-2)
 
-if sys.version_info >= (3, 0):
-    def exec_file(x):
-        e = getattr(__builtins__, "exec")
-        return e(open(x).read(), globals(), globals())
-else:
-    exec_file = execfile
+def exec_file(x):
+    e = getattr(__builtins__, "exec")
+    return e(open(x).read(), globals(), globals())
+
 exec_file(%(script)r)
 """ % {"suds.__version__": suds.__version__,
     "script": script.basename,

--- a/tests/testutils/compare_sax__pytest_assert_rewrite_needed.py
+++ b/tests/testutils/compare_sax__pytest_assert_rewrite_needed.py
@@ -31,8 +31,6 @@ import suds.sax.document
 import suds.sax.element
 import suds.sax.parser
 
-from six import text_type, u
-
 import sys
 
 
@@ -227,11 +225,11 @@ class CompareSAX:
     def __element_name(element):
         """Returns a given SAX element's name as unicode or '???' on error."""
         try:
-            return text_type(element.name)
+            return str(element.name)
         except (KeyboardInterrupt, SystemExit):
             raise
         except Exception:
-            return u("???")
+            return "???"
 
     def __element2element(self, lhs, rhs, context_info=(0, 1)):
         """
@@ -282,8 +280,8 @@ class CompareSAX:
         bytes object.
 
         """
-        if isinstance(data, text_type):
-            data = data.encode("utf-8")
+        if isinstance(data, str):
+            data = data.encode()
         return suds.sax.parser.Parser().parse(string=data)
 
     def __pop_context(self):

--- a/tools/setup_base_environments.py
+++ b/tools/setup_base_environments.py
@@ -25,7 +25,6 @@ The environments should have the following Python packages installed:
   * setuptools (for installing pip)
   * pip (for installing everything except itself)
   * pytest (for running the project's test suite)
-  * six (Python 2/3 compatibility layer used in the project's test suite)
   * virtualenv (for creating virtual Python environments)
 plus certain specific Python versions may require additional backward
 compatibility support packages.
@@ -124,8 +123,7 @@ from suds_devel.egg import zip_eggs_in_folder
 from suds_devel.environment import BadEnvironment, Environment
 from suds_devel.exception import EnvironmentSetupError
 from suds_devel.parse_version import parse_version
-from suds_devel.requirements import (pytest_requirements, six_requirements,
-    virtualenv_requirements)
+from suds_devel.requirements import pytest_requirements, virtualenv_requirements
 import suds_devel.utility as utility
 
 
@@ -763,7 +761,6 @@ def prepare_pip_requirements_file_if_needed(requirements):
 def prepare_pip_requirements(env):
     requirements = list(itertools.chain(
         pytest_requirements(env.sys_version_info, env.ctypes_version),
-        six_requirements(env.sys_version_info),
         virtualenv_requirements(env.sys_version_info)))
     janitor = prepare_pip_requirements_file_if_needed(requirements)
     return requirements, janitor

--- a/tools/suds_devel/requirements.py
+++ b/tools/suds_devel/requirements.py
@@ -248,22 +248,6 @@ def pytest_requirements(version_info=None, ctypes_version=_Unspecified):
     yield requirement_spec("pytest", *pytest_version)
 
 
-def six_requirements(version_info=sys.version_info):
-    """
-    Generate Python version specific six package requirements.
-
-    The requirements are returned as setuptools/pip compatible requirement
-    specification strings.
-
-    """
-    if version_info < (2, 5):
-        # 'six' release 1.5 dropped Python 2.4.x compatibility.
-        yield requirement_spec("six",
-            ("<", lowest_version_string_with_prefix("1.5")))
-    else:
-        yield requirement_spec("six")
-
-
 def virtualenv_requirements(version_info=sys.version_info):
     """
     Generate Python version specific virtualenv package requirements.


### PR DESCRIPTION
There are now 1830 instead of 1846 tests.

6 were already being skipped
4 in TestXLong and 4 in TestXInteger because `long` does not exist in Python 3
2 had incorrect version skipping (with current pytest anyway), should have been:

```diff
--- a/tests/test_xsd_builtins.py
+++ b/tests/test_xsd_builtins.py
@@ -164,10 +164,10 @@
 
     @pytest.mark.parametrize("source", (
         None,
-        pytest.mark.skipif(sys.version_info >= (3,),
-            reason="int == long since Python 3.0")(long(0)),
-        pytest.mark.skipif(sys.version_info >= (3,),
-            reason="int == long since Python 3.0")(long(1)),
+        pytest.param(long(0), marks=pytest.mark.skipif(sys.version_info >= (3,),
+            reason="int == long since Python 3.0")),
+        pytest.param(long(1), marks=pytest.mark.skipif(sys.version_info >= (3,),
+            reason="int == long since Python 3.0")),
         "x",
         "True",
         "False",
```
