### PR TITLE
Optimize Domain and Key Validation with Sets

### DIFF
--- a/suds/properties.py
+++ b/suds/properties.py
@@ -68,22 +68,18 @@ class Link(object):
         if pA in pB.links or \
            pB in pA.links:
             raise Exception('Already linked')
-        dA = pA.domains()
-        dB = pB.domains()
-        for d in dA:
-            if d in dB:
-                raise Exception('Duplicate domain "%s" found' % d)
-        for d in dB:
-            if d in dA:
-                raise Exception('Duplicate domain "%s" found' % d)
-        kA = list(pA.keys())
-        kB = list(pB.keys())
-        for k in kA:
-            if k in kB:
-                raise Exception('Duplicate key %s found' % k)
-        for k in kB:
-            if k in kA:
-                raise Exception('Duplicate key %s found' % k)
+        dA = set(pA.domains())
+        dB = set(pB.domains())
+        duplicate_domains = dA.intersection(dB)
+        if duplicate_domains:
+            raise Exception('Duplicate domains found: %s' % ', '.join(map(str, duplicate_domains)))
+        
+        kA = set(pA.keys())
+        kB = set(pB.keys())
+        duplicate_keys = kA.intersection(kB)
+        if duplicate_keys:
+            raise Exception('Duplicate keys found: %s' % ', '.join(map(str, duplicate_keys)))
+        
         return self
 
     def teardown(self):


### PR DESCRIPTION
## Overview
This PR refactors the `validate` method in the `Link` class to use `set` for validating domains and keys instead of iterating over lists with linear searches. The core logic remains unchanged, only the implementation has been improved for better performance and readability.

## Why This Change?
Using `set` instead of list-based searches makes sense for several reasons:

1. **Performance Boost**:
   - The original code used loops with `in` checks, resulting in a time complexity of `O(m * n)` for both domains and keys, where `m` and `n` are the sizes of the respective collections.
   - With `set`, lookups drop to an average of `O(1)` thanks to hash-based operations. The overall complexity becomes `O(m + n)`—a linear improvement.
   - While the performance gain might not be drastic for small datasets, it scales better as the number of domains or keys grows, making this a proactive optimization.

2. **No Logic Change**:
   - The validation rules remain identical: we still check for duplicate domains and keys, and raise exceptions with meaningful messages if duplicates are found. The behavior is preserved—just faster and cleaner.

3. **Cleaner, More Organized Code**:
   - Replacing nested loops with `set.intersection()` reduces the code footprint and makes it more readable.
   - The updated error messages now list *all* duplicates (e.g., `Duplicate keys found: a, b`) instead of stopping at the first one, which could help debugging without altering the intent.

## What Changed?
- Converted `domains()` and `keys()` to `set` and used `intersection` to find duplicates.
- Updated exception messages with `join(map(str, duplicates))` for a full duplicate list.
- Eliminated redundant loops, keeping the code DRY (Don't Repeat Yourself).