### PR TITLE
Fix regression in v1.2.0 that caused body to be None instead of empty element

### DIFF
--- a/suds/bindings/binding.py
+++ b/suds/bindings/binding.py
@@ -147,11 +147,11 @@ class Binding(object):
 
         """
         soapenv = replyroot.getChild("Envelope", envns)
-        if not soapenv:
+        if soapenv is None:
             soapenv = replyroot.getChild("Envelope", envns12)
         soapenv.promotePrefixes()
         soapbody = soapenv.getChild("Body", envns)
-        if not soapbody:
+        if soapbody is None:
             soapbody = soapenv.getChild("Body", envns12)
         soapbody = self.multiref.process(soapbody)
         nodes = self.replycontent(method, soapbody)

--- a/tests/test_reply_handling.py
+++ b/tests/test_reply_handling.py
@@ -152,6 +152,19 @@ def test_disabling_automated_simple_interface_unwrapping():
     assert response.Elemento == "La-di-da-da-da"
 
 
+def test_empty_body():
+    wsdl = testutils.wsdl("", output=None)
+    client = testutils.client_from_wsdl(wsdl)
+    reply = """\
+<?xml version="1.0"?>
+<env:Envelope xmlns:env="http://schemas.xmlsoap.org/soap/envelope/">
+  <env:Body/>
+</env:Envelope>
+"""
+    inject = {"reply": suds.byte_str(reply)}
+    assert client.service.f(__inject=inject) is None
+
+
 def test_empty_reply():
     client = testutils.client_from_wsdl(_wsdl__simple_f, faults=False)
     def f(status=None, description=None):


### PR DESCRIPTION
An empty element (`<s:Body/>`) satisfies `if not soapbody` check, however in this case we should not fall back to finding SOAP 1.2 body.

This change fixes an error that was happening in our project:
```pytb
  File "lib/python3.12/site-packages/suds/client.py", line 586, in __call__
    return client.invoke(args, kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "lib/python3.12/site-packages/suds/client.py", line 728, in invoke
    result = self.send(soapenv, timeout=timeout)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "lib/python3.12/site-packages/suds/client.py", line 777, in send
    return self.process_reply(reply.message, None, None)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "lib/python3.12/site-packages/suds/client.py", line 851, in process_reply
    result = replyroot and self.method.binding.output.get_reply(
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "lib/python3.12/site-packages/suds/bindings/binding.py", line 156, in get_reply
    soapbody = self.multiref.process(soapbody)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "lib/python3.12/site-packages/suds/bindings/multiref.py", line 50, in process
    self.build_catalog(body)
  File "lib/python3.12/site-packages/suds/bindings/multiref.py", line 101, in build_catalog
    for child in body.children:
                 ^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'children'
```